### PR TITLE
Build geoWrite cvt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ ASFLAGS = -g
 
 LOCALE ?= en
 
+OUTPUT ?= bin
+
 ifeq ($(LOCALE),en)
 ASFLAGS+=-D LOCALE=0 -I en
 else ifeq ($(LOCALE),de)
@@ -46,6 +48,13 @@ all: $(PREFIXED_OBJS) $(BUILD_DIR)/protection.o
 
 	./encrypt.py
 
+	rm -f build/current
+
+cvt: cvt.s geoWrite-cvt.cfg $(PREFIXED_OBJS) $(BUILD_DIR)/protection.o
+	rm -f build/current
+	ln -s $(LOCALE) build/current
+	$(AS) $(ASFLAGS) cvt.s -o $(BUILD_DIR)/cvt.o
+	ld65 -C geoWrite-cvt.cfg $(BUILD_DIR)/cvt.o -o $(BUILD_DIR)/geoWrite.cvt -Ln $(BUILD_DIR)/cvtsymbols.lbl
 	rm -f build/current
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,6 @@ ASFLAGS = -g
 
 LOCALE ?= en
 
-OUTPUT ?= bin
-
 ifeq ($(LOCALE),en)
 ASFLAGS+=-D LOCALE=0 -I en
 else ifeq ($(LOCALE),de)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,11 @@ The resulting files are the individual VLIR records, the file header, and the co
     geoWrite-fhdr.bin
     protection.bin
 
-The build process does not currently re-create a flat "CVT" VLIR file.
+The build process can re-create a flat "CVT" VLIR file with metadata (track & sector data, time stamp) fixed to values from `geoWrite_en_2.1_1988-07-06.cvt` file.
+
+To prepare cvt file enter
+
+    make && make cvt
 
 ## Binary Collection
 

--- a/cvt.s
+++ b/cvt.s
@@ -1,0 +1,87 @@
+
+; t&s (record block, info block) and timestamp matching
+; geoWrite_en_2.1_1988-07-06
+
+.SEGMENT "DIRENTRY"
+
+        .byte 131
+        .byte $06, $0b		; t&s of record block, irrelevant in CVT
+        .byte "GEOWRITE"
+        .res  (16 - 8), $a0
+        .byte $06, $03		; t&s of info block, irrelevant in CVT
+        .byte 1 ; VLIR structure
+        .byte 6 ; APPLICATION
+        .byte 88, 7, 6, 13, 16
+
+        .word 141		; size in 254-byte blocks
+        .byte "PRG formatted GEOS file"
+
+.segment "FILEINFO"
+.incbin "build/current/geoWrite-fhdr.bin", 2
+
+.segment "RECORDS"
+
+.import __VLIR0_START__, __VLIR0_LAST__
+.import __VLIR1_START__, __VLIR1_LAST__
+.import __VLIR2_START__, __VLIR2_LAST__
+.import __VLIR3_START__, __VLIR3_LAST__
+.import __VLIR4_START__, __VLIR4_LAST__
+.import __VLIR5_START__, __VLIR5_LAST__
+.import __VLIR6_START__, __VLIR6_LAST__
+.import __VLIR7_START__, __VLIR7_LAST__
+.import __VLIR8_START__, __VLIR8_LAST__
+
+	.byte .lobyte ((__VLIR0_LAST__ - __VLIR0_START__ - 1) /    254) + 1
+	.byte .lobyte ((__VLIR0_LAST__ - __VLIR0_START__ - 1) .MOD 254) + 2
+
+	.byte .lobyte ((__VLIR1_LAST__ - __VLIR1_START__ - 1) /    254) + 1
+	.byte .lobyte ((__VLIR1_LAST__ - __VLIR1_START__ - 1) .MOD 254) + 2
+
+	.byte .lobyte ((__VLIR2_LAST__ - __VLIR2_START__ - 1) /    254) + 1
+	.byte .lobyte ((__VLIR2_LAST__ - __VLIR2_START__ - 1) .MOD 254) + 2
+
+	.byte .lobyte ((__VLIR3_LAST__ - __VLIR3_START__ - 1) /    254) + 1
+	.byte .lobyte ((__VLIR3_LAST__ - __VLIR3_START__ - 1) .MOD 254) + 2
+
+	.byte .lobyte ((__VLIR4_LAST__ - __VLIR4_START__ - 1) /    254) + 1
+	.byte .lobyte ((__VLIR4_LAST__ - __VLIR4_START__ - 1) .MOD 254) + 2
+
+	.byte .lobyte ((__VLIR5_LAST__ - __VLIR5_START__ - 1) /    254) + 1
+	.byte .lobyte ((__VLIR5_LAST__ - __VLIR5_START__ - 1) .MOD 254) + 2
+
+	.byte .lobyte ((__VLIR6_LAST__ - __VLIR6_START__ - 1) /    254) + 1
+	.byte .lobyte ((__VLIR6_LAST__ - __VLIR6_START__ - 1) .MOD 254) + 2
+
+	.byte .lobyte ((__VLIR7_LAST__ - __VLIR7_START__ - 1) /    254) + 1
+	.byte .lobyte ((__VLIR7_LAST__ - __VLIR7_START__ - 1) .MOD 254) + 2
+
+	.byte .lobyte ((__VLIR8_LAST__ - __VLIR8_START__ - 1) /    254) + 1
+	.byte .lobyte ((__VLIR8_LAST__ - __VLIR8_START__ - 1) .MOD 254) + 2
+
+.segment "VLIR0"
+.incbin "build/current/geoWrite-0.bin"
+
+.segment "VLIR1"
+.incbin "build/current/geoWrite-1.bin"
+
+.segment "VLIR2"
+.incbin "build/current/geoWrite-2.bin"
+
+.segment "VLIR3"
+.incbin "build/current/geoWrite-3.bin"
+
+.segment "VLIR4"
+.incbin "build/current/geoWrite-4.bin"
+
+.segment "VLIR5"
+.incbin "build/current/geoWrite-5.bin"
+
+.segment "VLIR6"
+.incbin "build/current/geoWrite-6.bin"
+
+.segment "VLIR7"
+.incbin "build/current/geoWrite-7.bin"
+
+.segment "VLIR8"
+.incbin "build/current/geoWrite-8.bin"
+

--- a/geoWrite-cvt.cfg
+++ b/geoWrite-cvt.cfg
@@ -1,0 +1,28 @@
+
+MEMORY {
+	CVT:	file = "%O", start = $0, size = $40000;
+	VLIR0:  start = $0400, size = $2E44, define = yes;
+	VLIR1:  start = $3244, size = 4000, define = yes;
+	VLIR2:  start = $3244, size = 4000, define = yes;
+	VLIR3:  start = $3244, size = 4000, define = yes;
+	VLIR4:  start = $3244, size = 4000, define = yes;
+	VLIR5:  start = $3244, size = 4000, define = yes;
+	VLIR6:  start = $3244, size = 4000, define = yes;
+	VLIR7:  start = $3244, size = 4000, define = yes;
+	VLIR8:  start = $0680, size = 4000, define = yes;
+}
+
+SEGMENTS {
+	DIRENTRY:	type = ro, load=CVT, align = $FE;
+	FILEINFO:	type = ro, load=CVT, align = $FE;
+	RECORDS:	type = ro, load=CVT, align = $FE;
+	VLIR0:		type = ro, run = VLIR0, load=CVT, align_load = $FE;
+	VLIR1:		type = ro, run = VLIR1, load=CVT, align_load = $FE;
+	VLIR2:		type = ro, run = VLIR2, load=CVT, align_load = $FE;
+	VLIR3:		type = ro, run = VLIR3, load=CVT, align_load = $FE;
+	VLIR4:		type = ro, run = VLIR4, load=CVT, align_load = $FE;
+	VLIR5:		type = ro, run = VLIR5, load=CVT, align_load = $FE;
+	VLIR6:		type = ro, run = VLIR6, load=CVT, align_load = $FE;
+	VLIR7:		type = ro, run = VLIR7, load=CVT, align_load = $FE;
+	VLIR8:		type = ro, RUN = VLIR8, load=CVT, align_load = $FE;
+}


### PR DESCRIPTION
`cvt` target for Makefile and support files to rebuild the CVT-formatted file